### PR TITLE
Renomeando Entidade de Igreja para Instituicao

### DIFF
--- a/model/entities/Instituicao.php
+++ b/model/entities/Instituicao.php
@@ -1,5 +1,5 @@
 <?php
-class Igreja{
+class Instituicao{
     private int $id;
     private string $nome;
     private string $email;

--- a/model/entities/Instituicao.php
+++ b/model/entities/Instituicao.php
@@ -4,8 +4,8 @@ class Instituicao{
     private string $nome;
     private string $email;
     private string $endereco;
-    private string $telefone;  
-    
+    private string $telefone;
+
     function __construct($id, $nome, $email, $endereco, $telefone) {
         $this->id = $id;
         $this->nome = $nome;
@@ -16,17 +16,17 @@ class Instituicao{
 
     function getId() { return $this->id; }
     function setId($id) { $this->id = $id; }
-    
+
     function getNome() { return $this->nome; }
     function setNome($nome) { $this->nome = $nome; }
 
     function getEmail() { return $this->email; }
-    function setEmail($email){ $this->email = $email; }
+    function setEmail($email) { $this->email = $email; }
 
     function getEndereco() { return $this->endereco; }
-    function setEndereco($endereco){ $this->endereco = $endereco; }
+    function setEndereco($endereco) { $this->endereco = $endereco; }
 
     function getTelefone() { return $this->telefone; }
-    function setTelefone($telefone){ $this->telefone = $telefone; }
+    function setTelefone($telefone) { $this->telefone = $telefone; }
 }
 ?>


### PR DESCRIPTION
Decidi mudar o nome da entidade, de Igreja para Instituicao, afim de tornar mais genérico e consequentemente escalável, afinal o nome igreja atenderia apenas instituições do tipo igreja, mas o nome instituição abrange todo tipo de instituição tornando  sistema muito mais abrangente.